### PR TITLE
load airport names from apt.dat file

### DIFF
--- a/src/airports/airportsdata.h
+++ b/src/airports/airportsdata.h
@@ -12,6 +12,7 @@
 
 #include <QWidget>
 #include <QProgressDialog>
+#include <QHash>
 
 #include "xobjects/mainobject.h"
 
@@ -19,6 +20,7 @@ class AirportsData
 {
 public:
 	//AirportsData();
+	static QHash<QString, QString> getAirportNameMap(MainObject *mainObject);
 	static bool import(QProgressDialog &progress, MainObject *mainObject);
 };
 


### PR DESCRIPTION
The airport list so far did not show the airport names as they are not contained in the scenery directories.
This commit first parses $FG_ROOT/Airports/apt.dat.gz to build a mapping between the airport ICAO codes and the airport names before loading the remaining data from the scenery folders.
Airport loading time increases significantly, but the list now shows the airport names.
